### PR TITLE
Removing energy consumption mean calculation

### DIFF
--- a/Criterion/Analysis.hs
+++ b/Criterion/Analysis.hs
@@ -157,14 +157,12 @@ analyseSample i name meas = do
   resamps <- liftIO $ resample gen ests resamples stime
   let [estMean,estStdDev] = B.bootstrapBCA confInterval stime ests resamps
       ov = outlierVariance estMean estStdDev (fromIntegral n)
-      energy = (V.sum $ V.map (measEnergy) meas) / (fromIntegral n)
       an = SampleAnalysis {
                anRegress    = rs
              , anOverhead   = overhead
              , anMean       = estMean
              , anStdDev     = estStdDev
              , anOutlierVar = ov
-             , anEnergy     = energy
              }
   return Report {
       reportNumber   = i

--- a/Criterion/Internal.hs
+++ b/Criterion/Internal.hs
@@ -77,7 +77,6 @@ runAndAnalyseOne i desc bm = do
           Just t  -> bs secs "time" t >> bs r2 "" regRSquare
       bs secs "mean" anMean
       bs secs "std dev" anStdDev
-      note "%-20s %-10s\n" "energy" (show anEnergy)
       forM_ others $ \Regression{..} -> do
         _ <- bs r2 (regResponder ++ ":") regRSquare
         forM_ (Map.toList regCoeffs) $ \(prd,val) ->

--- a/Criterion/Types.hs
+++ b/Criterion/Types.hs
@@ -574,7 +574,6 @@ data SampleAnalysis = SampleAnalysis {
     , anOutlierVar :: OutlierVariance
       -- ^ Description of the effects of outliers on the estimated
       -- variance.
-    , anEnergy     :: Double
     } deriving (Eq, Read, Show, Typeable, Data, Generic)
 
 instance FromJSON SampleAnalysis
@@ -582,8 +581,8 @@ instance ToJSON SampleAnalysis
 
 instance Binary SampleAnalysis where
     put SampleAnalysis{..} = do
-      put anRegress; put anOverhead; put anMean; put anStdDev; put anOutlierVar; put anEnergy
-    get = SampleAnalysis <$> get <*> get <*> get <*> get <*> get <*> get
+      put anRegress; put anOverhead; put anMean; put anStdDev; put anOutlierVar
+    get = SampleAnalysis <$> get <*> get <*> get <*> get <*> get
 
 instance NFData SampleAnalysis where
     rnf SampleAnalysis{..} =


### PR DESCRIPTION
We can use the linear regression of the energy metric (throght --regress
option) instead of the mean.

Also the mean calculation was not right, the total energy consumption
(sum) should be divided by the number of iterations (niters) instead of
the number of measures (n).
