### PR TITLE
Open msr device only once

### DIFF
--- a/Criterion/Main.hs
+++ b/Criterion/Main.hs
@@ -50,7 +50,7 @@ import Criterion.IO.Printf (printError, writeCsv)
 import Criterion.Internal (runAndAnalyse, runFixedIters)
 import Criterion.Main.Options (MatchType(..), Mode(..), defaultConfig, describe,
                                versionInfo)
-import Criterion.Measurement (initializeTime)
+import Criterion.Measurement (initializeTime, initializeRAPL, finishRAPL)
 import Criterion.Monad (withConfig)
 import Criterion.Types
 import Data.List (isPrefixOf, sort, stripPrefix)
@@ -144,7 +144,9 @@ defaultMainWith defCfg bs = do
         writeCsv ("Name","Mean","MeanLB","MeanUB","Stddev","StddevLB",
                   "StddevUB")
         liftIO initializeTime
+        liftIO initializeRAPL
         runAndAnalyse shouldRun bsgroup
+        liftIO finishRAPL
 
 -- | Display an error message from a command line parsing failure, and
 -- exit.

--- a/Criterion/Measurement.hs
+++ b/Criterion/Measurement.hs
@@ -19,7 +19,9 @@ module Criterion.Measurement
     , getCPUTime
     , getCycles
     , getGCStats
+    , initializeRAPL
     , getEnergy
+    , finishRAPL
     , secs
     , measure
     , runBenchmark
@@ -210,5 +212,11 @@ foreign import ccall unsafe "criterion_gettime" getTime :: IO Double
 -- (system) time into a single measure.
 foreign import ccall unsafe "criterion_getcputime" getCPUTime :: IO Double
 
+-- | Set up energy measurement.
+foreign import ccall unsafe "criterion_initrapl" initializeRAPL :: IO ()
+
 -- | Return the amount of energy consumed
 foreign import ccall unsafe "criterion_getenergypacket" getEnergy :: IO Double
+
+-- | Finish energy measurement.
+foreign import ccall unsafe "criterion_finishrapl" finishRAPL :: IO ()

--- a/cbits/energy-rapl.c
+++ b/cbits/energy-rapl.c
@@ -1,26 +1,31 @@
 #include <unistd.h>
 #include "rapl.h"
 
+static int fd_msr = 0;
+static struct rapl_units r_units;
+static int units_ok;
+
+void criterion_initrapl(void)
+{
+    char core = 0;  // NOTE: Just core 0
+    fd_msr = rapl_open_msr(core);
+    units_ok = rapl_get_units(fd_msr, &r_units);
+}
+
 double criterion_getenergypacket(void)
 {
-
-    char core = 0;  // NOTE: Just core 0
-    int fd_msr = 0;
+    if (!units_ok || fd_msr == 0) {
+        return -1;
+    }
 
     struct rapl_raw_power_counters rpc;
 
-    fd_msr = rapl_open_msr( core );
+    rapl_get_raw_power_counters(fd_msr, &r_units, &rpc);
 
-    struct rapl_units r_units;
-    if ( !rapl_get_units( fd_msr , &r_units ) ) {
-        return -1;
-    }
-    //rapl_print_units( &r_units );
+    return rapl_get_energy(&rpc);
+}
 
-    rapl_get_raw_power_counters( fd_msr , &r_units , &rpc );
-    //rapl_print_raw_power_counters ( fd_msr, &r_units );
-
-    close( fd_msr );
-
-    return rapl_get_energy( &rpc );
+void criterion_finishrapl(void)
+{
+    close(fd_msr);
 }


### PR DESCRIPTION
There is no need to open/close the msr device each time the getTime
function is called.

This patch slightly reduce the overhead of fetching the energy
consumption info from RAPL.
