### PR TITLE
[WIP] Workaround to overflow issue in power consumption

### DIFF
--- a/cbits/energy-rapl.c
+++ b/cbits/energy-rapl.c
@@ -11,12 +11,22 @@ pthread_t thread;
 
 void *thread_sum_energy_packet(void *arg)
 {
+    struct rapl_power_diff diff;
+    struct rapl_raw_power_counters prev, next;
+    rapl_get_raw_power_counters(fd_msr, &r_units, &prev);
+
     for (;;)
     {
         sleep(15);
-        struct rapl_raw_power_counters rpc;
-        rapl_get_raw_power_counters(fd_msr, &r_units, &rpc);
-        energy_sum += rapl_get_energy(&rpc);
+
+        rapl_get_raw_power_counters(fd_msr, &r_units, &next);
+        rapl_get_power_diff(&prev, &next, &diff);
+
+        if (diff.pkg < 0)
+            continue;
+
+        prev = next;
+        energy_sum += diff.pkg;
     }
 }
 

--- a/cbits/energy-rapl.c
+++ b/cbits/energy-rapl.c
@@ -1,28 +1,40 @@
 #include <unistd.h>
+#include <pthread.h>
 #include "rapl.h"
 
 static int fd_msr = 0;
 static struct rapl_units r_units;
 static int units_ok;
 
+static double energy_sum = 0;
+pthread_t thread;
+
+void *thread_sum_energy_packet(void *arg)
+{
+    for (;;)
+    {
+        sleep(15);
+        struct rapl_raw_power_counters rpc;
+        rapl_get_raw_power_counters(fd_msr, &r_units, &rpc);
+        energy_sum += rapl_get_energy(&rpc);
+    }
+}
+
 void criterion_initrapl(void)
 {
     char core = 0;  // NOTE: Just core 0
     fd_msr = rapl_open_msr(core);
     units_ok = rapl_get_units(fd_msr, &r_units);
+
+    pthread_create(&thread, NULL, thread_sum_energy_packet, NULL);
 }
 
 double criterion_getenergypacket(void)
 {
-    if (!units_ok || fd_msr == 0) {
+    if (!units_ok || fd_msr == 0)
         return -1;
-    }
 
-    struct rapl_raw_power_counters rpc;
-
-    rapl_get_raw_power_counters(fd_msr, &r_units, &rpc);
-
-    return rapl_get_energy(&rpc);
+    return energy_sum;
 }
 
 void criterion_finishrapl(void)

--- a/cbits/rapl.h
+++ b/cbits/rapl.h
@@ -19,72 +19,72 @@
 
 #define MSR_ENERGY_STATUS_MASK 0xffffffff
 
-//#define MSR_PKG_RAPL_POWER_LIMIT 0x610
+#define MSR_PKG_RAPL_POWER_LIMIT 0x610
 #define MSR_PKG_ENERGY_STATUS 0x611
-//#define MSR_PKG_PERF_STATUS 0x613
-//#define MSR_PKG_POWER_INFO 0x614
+#define MSR_PKG_PERF_STATUS 0x613
+#define MSR_PKG_POWER_INFO 0x614
 
-//#define MSR_PP0_POWER_LIMIT 0x638
+#define MSR_PP0_POWER_LIMIT 0x638
 #define MSR_PP0_ENERGY_STATUS 0x639
-//#define MSR_PP0_POLICY 0x63A
-//#define MSR_PP0_PERF_STATUS 0x63B
+#define MSR_PP0_POLICY 0x63A
+#define MSR_PP0_PERF_STATUS 0x63B
 
 /* MSRs that are supported on 062A */
-//#define MSR_PP1_POWER_LIMIT 0x640
+#define MSR_PP1_POWER_LIMIT 0x640
 #define MSR_PP1_ENERGY_STATUS 0x641
-//#define MSR_PP1_POLICY 0x642
+#define MSR_PP1_POLICY 0x642
 
 /* MSRs that are supported on 062D */
-//#define MSR_DRAM_POWER_LIMIT 0x618
-//#define MSR_DRAM_ENERGY_STATUS 0x619
-//#define MSR_DRAM_PERF_STATUS 0x61B
-//#define MSR_DRAM_POWER_INFO 0x61C
+#define MSR_DRAM_POWER_LIMIT 0x618
+#define MSR_DRAM_ENERGY_STATUS 0x619
+#define MSR_DRAM_PERF_STATUS 0x61B
+#define MSR_DRAM_POWER_INFO 0x61C
 
 /* Defined for use with MSR_RAPL_POWER_UNIT Register */
-//#define RAPL_POWER_UNIT_OFFSET 0x00
-//#define RAPL_POWER_UNIT_MASK 0x0F
+#define RAPL_POWER_UNIT_OFFSET 0x00
+#define RAPL_POWER_UNIT_MASK 0x0F
 #define RAPL_ENERGY_UNIT_OFFSET 0x08
 #define RAPL_ENERGY_UNIT_MASK 0x1F
-//#define RAPL_TIME_UNIT_OFFSET 0x10
-//#define RAPL_TIME_UNIT_MASK 0xF
+#define RAPL_TIME_UNIT_OFFSET 0x10
+#define RAPL_TIME_UNIT_MASK 0xF
 
 /* Defined for use with MSR_PKG_POWER_INFO Register */
-//#define RAPL_THERMAL_SPEC_POWER_OFFSET 0x0
-//#define RAPL_THERMAL_SPEC_POWER_MASK 0x7FFF
-//#define RAPL_MINIMUM_POWER_OFFSET 0x10
-//#define RAPL_MINIMUM_POWER_MASK 0x7FFF
-//#define RAPL_MAXIMUM_POWER_OFFSET 0x20
-//#define RAPL_MAXIMUM_POWER_MASK 0x7FFF
-//#define RAPL_MAXIMUM_TIME_WINDOW_OFFSET 0x30
-//#define RAPL_MAXIMUM_TIME_WINDOW_MASK 0x3F
+#define RAPL_THERMAL_SPEC_POWER_OFFSET 0x0
+#define RAPL_THERMAL_SPEC_POWER_MASK 0x7FFF
+#define RAPL_MINIMUM_POWER_OFFSET 0x10
+#define RAPL_MINIMUM_POWER_MASK 0x7FFF
+#define RAPL_MAXIMUM_POWER_OFFSET 0x20
+#define RAPL_MAXIMUM_POWER_MASK 0x7FFF
+#define RAPL_MAXIMUM_TIME_WINDOW_OFFSET 0x30
+#define RAPL_MAXIMUM_TIME_WINDOW_MASK 0x3F
 
 struct rapl_units {
-	//double power_units;
+	double power_units;
 	double energy_units;
-	//double time_units;
+	double time_units;
 };
 
-//struct rapl_pkg_power_info {
-	//double thermal_spec_power;
-	//double minimum_power;
-	//double maximum_power;
-	//double time_window;
-//};
+struct rapl_pkg_power_info {
+	double thermal_spec_power;
+	double minimum_power;
+	double maximum_power;
+	double time_window;
+};
 
 struct rapl_raw_power_counters {
 	double pkg;
 	double pp0;
 	double pp1;
-	//double dram;
+	double dram;
 };
 
-//struct rapl_power_diff {
-	//double pkg;
-	//double cpu;
-	//double gpu;
-	//double dram;
-	//double uncore;
-//};
+struct rapl_power_diff {
+	double pkg;
+	double cpu;
+	double gpu;
+	double dram;
+	double uncore;
+};
 
 #define RAPL_GET_ENERGY_STATUS(fd_msr, runits, ID) \
 	((double)rapl_get_msr((fd_msr), ID) * (runits)->energy_units)
@@ -103,23 +103,16 @@ char rapl_available();
 char rapl_get_units(int fd_msr, struct rapl_units * ru);
 void rapl_print_units(struct rapl_units * ru);
 
-//char rapl_get_pkg_power_info(int fd_msr, struct rapl_units * ru, struct rapl_pkg_power_info * pinfo);
-//void rapl_print_pkg_power_info(struct rapl_pkg_power_info * pinfo);
-
-int rapl_get_cpu_model();
+char rapl_get_pkg_power_info(int fd_msr, struct rapl_units * ru, struct rapl_pkg_power_info * pinfo);
+void rapl_print_pkg_power_info(struct rapl_pkg_power_info * pinfo);
 
 void rapl_get_raw_power_counters(int fd_msr, struct rapl_units * runits, struct rapl_raw_power_counters * pc);
 void rapl_print_raw_power_counters (int fd_msr, struct rapl_units * runits);
 
-///////////////////////
+void rapl_get_power_diff(struct rapl_raw_power_counters * start, struct rapl_raw_power_counters * stop,
+		struct rapl_power_diff * pd);
 
-double rapl_get_energy( struct rapl_raw_power_counters *pc );
-
-///////////////////////
-
-//void rapl_get_power_diff(struct rapl_raw_power_counters * start, struct rapl_raw_power_counters * stop, struct rapl_power_diff * pd);
-
-//void rapl_print_power_diff(struct rapl_power_diff * pd);
+void rapl_print_power_diff(struct rapl_power_diff * pd);
 
 char rapl_pkg_available();
 char rapl_pp0_available();


### PR DESCRIPTION
This is a work in progress.

The idea is to use a different thread to collect the power consumption information regularly, as we know the overflow might happen after 60 seconds. As we discussed, we know the overflow can also happen before 60 seconds, so this is still an issue.

Issues to solve:
- [x] overflow
- [x] there is a data race in the `energy_sum` variable
- [ ] `criterion_getenergypacket` might be called during a sleep period of the second thread

@luisgabriel  do you think there is a better way? What about the isses pointed out?
