### PR TITLE
Handle computers with multiple processors

### DIFF
--- a/cbits/energy-rapl.c
+++ b/cbits/energy-rapl.c
@@ -1,31 +1,100 @@
+#include <stdio.h>
 #include <unistd.h>
 #include "rapl.h"
 
-static int fd_msr = 0;
+#define MAX_PACKAGES 32
+
+static int fd_msr[MAX_PACKAGES];
 static struct rapl_units r_units;
 static int units_ok;
+static int num_packages;
+
+static int get_kernel_nr_cpus(void)
+{
+    int nr_cpus = 1;
+    FILE *fff = fopen("/sys/devices/system/cpu/kernel_max","r");
+    if (fff == NULL)
+        return nr_cpus;
+
+    int num_read = fscanf(fff, "%d", &nr_cpus);
+    fclose(fff);
+    return (num_read == 1) ? (nr_cpus + 1) : 1;
+}
 
 void criterion_initrapl(void)
 {
-    char core = 0;  // NOTE: Just core 0
-    fd_msr = rapl_open_msr(core);
-    units_ok = rapl_get_units(fd_msr, &r_units);
+    int nr_cpus = get_kernel_nr_cpus();
+    int cpu_to_use[nr_cpus];
+
+    int package;
+    char filename[256];
+    num_packages = 0;
+
+    // Fill with placeholders
+    for (int i = 0; i < nr_cpus; i++)
+        cpu_to_use[i] = -1;
+
+    int j = 0;
+    // Detect the amount of packages
+    while (1) {
+       sprintf(filename, "/sys/devices/system/cpu/cpu%d/topology/physical_package_id", j);
+       FILE *fff = fopen(filename, "r");
+       if (fff == NULL)
+           break;
+
+       int num_read = fscanf(fff, "%d", &package);
+       fclose(fff);
+       if (num_read != 1)
+           break;
+
+       // Check if a new package
+       if ((package >= 0) && (package < nr_cpus)) {
+           if (cpu_to_use[package] == -1) {
+               cpu_to_use[package] = j;
+               num_packages++;
+           }
+       } else {
+           perror("Package outside of allowed range\n");
+           break;
+       }
+
+       j++;
+    }
+
+    printf("Total packages found: %d\n", num_packages);
+
+    for (int i = 0; i < num_packages; i++) {
+        fd_msr[i] = rapl_open_msr(cpu_to_use[i]);
+        if (fd_msr[i] <= 0) {
+            char msg[256];
+            sprintf(msg, "Could not open msr %d\n", cpu_to_use[i]);
+            perror(msg);
+        }
+    }
+
+    units_ok = rapl_get_units(fd_msr[0], &r_units);
 }
 
 double criterion_getenergypacket(void)
 {
-    if (!units_ok || fd_msr == 0) {
+    if (!units_ok) {
+        perror("Invalid units!");
         return -1;
     }
 
     struct rapl_raw_power_counters rpc;
+    double total_package_energy = 0.0;
 
-    rapl_get_raw_power_counters(fd_msr, &r_units, &rpc);
+    for (int i = 0; i < num_packages; i++) {
+        rapl_get_raw_power_counters(fd_msr[i], &r_units, &rpc);
+        total_package_energy += rpc.pkg;
+    }
 
-    return rpc.pkg;
+    return total_package_energy;
 }
 
 void criterion_finishrapl(void)
 {
-    close(fd_msr);
+    for (int i = 0; i < num_packages; i++)
+        close(fd_msr[i]);
 }

--- a/cbits/energy-rapl.c
+++ b/cbits/energy-rapl.c
@@ -31,7 +31,8 @@ void criterion_initrapl(void)
     num_packages = 0;
 
     // Fill with placeholders
-    for (int i = 0; i < nr_cpus; i++)
+    int i;
+    for (i = 0; i < nr_cpus; i++)
         cpu_to_use[i] = -1;
 
     int j = 0;
@@ -63,7 +64,7 @@ void criterion_initrapl(void)
 
     printf("Total packages found: %d\n", num_packages);
 
-    for (int i = 0; i < num_packages; i++) {
+    for (i = 0; i < num_packages; i++) {
         fd_msr[i] = rapl_open_msr(cpu_to_use[i]);
         if (fd_msr[i] <= 0) {
             char msg[256];
@@ -85,7 +86,8 @@ double criterion_getenergypacket(void)
     struct rapl_raw_power_counters rpc;
     double total_package_energy = 0.0;
 
-    for (int i = 0; i < num_packages; i++) {
+    int i;
+    for (i = 0; i < num_packages; i++) {
         rapl_get_raw_power_counters(fd_msr[i], &r_units, &rpc);
         total_package_energy += rpc.pkg;
     }
@@ -95,6 +97,7 @@ double criterion_getenergypacket(void)
 
 void criterion_finishrapl(void)
 {
-    for (int i = 0; i < num_packages; i++)
+    int i;
+    for (i = 0; i < num_packages; i++)
         close(fd_msr[i]);
 }


### PR DESCRIPTION
We were collecting the energy consumption of a single processor package.

This patch collects the energy consumption of each package and sum it
up to get the total energy consumption.

The code was based on the PAPI RAPL code [1][2].

[1] http://icl.cs.utk.edu/papi/
[2] http://gist.github.com/luisgabriel/f91656a6662e21a2ff9c
